### PR TITLE
Crash Fix for deinitBuffering() on Monochrome Calculators

### DIFF
--- a/n2DLib.c
+++ b/n2DLib.c
@@ -80,16 +80,18 @@ void updateScreen()
 
 void deinitBuffering()
 {
-	// Handle monochrome screens-specific shit again
-	if(is_classic)
-		*((int32_t*)0xC000001C) = (*((int32_t*)0xC000001C) & ~0x0e) | 0x04;
-	*(void**)(0xC0000010) = SCREEN_BACKUP;
 	if(swapped)
 	{
 		temp = *(void**)0xC0000010;
 		*(void**)0xC0000010 = INV_BUFF;
 		INV_BUFF = temp;
 	}
+	
+	// Handle monochrome screens-specific shit again
+	if(is_classic)
+		*((int32_t*)0xC000001C) = (*((int32_t*)0xC000001C) & ~0x0e) | 0x04;
+	*(void**)(0xC0000010) = SCREEN_BACKUP;
+
 	free(INV_BUFF);
 	free(ALT_SCREEN_BASE_ADDRESS);
 	free(BUFF_BASE_ADDRESS);


### PR DESCRIPTION
Using n2DLib with a monochrome calculator, calculator may run in some crashes when you call deinitBufferring(). That's because n2DLib's monochrome handling is done before checking if the screen has been swapped in deinitBuffering() function. It should be after. So, that said, the fix is very simple. Just need change some lines in deinitBuffering().